### PR TITLE
Fixed extra bracket in rmloca.script which caused errors when running.

### DIFF
--- a/scripts/rmlocal.script
+++ b/scripts/rmlocal.script
@@ -42,7 +42,7 @@ rm_time () {
 rm_space () {
 	maxSize=$(($REMOVE_LOCAL_FILES_WHEN_SPACE_EXCEEDS_GB * 1000 * 1000 * 1000))
 	currentSize="$(du -sb "$local_decrypt_dir" | awk '{print $1}')"
-	if [ "$maxSize" -gt "$currentSize" ]]; then
+	if [ "$maxSize" -gt "$currentSize" ]; then
 			echo "Current size of $(($currentSize / 1000 / 1000 / 1000)) GB has not exceeded $REMOVE_LOCAL_FILES_WHEN_SPACE_EXCEEDS_GB GB"
 			exit 02
 	fi


### PR DESCRIPTION
There was an issue where the duplicate bracket inside the rmlocal script would result in the method breaking. Removing it fixes it and now gives the correct messaging. 