### PR TITLE
Update rmlocal.script

### DIFF
--- a/scripts/rmlocal.script
+++ b/scripts/rmlocal.script
@@ -35,7 +35,7 @@ rm_time () {
 
 			# Move file to remote destination[s], retaining path
 			echo "[ $(date $(printenv DATE_FORMAT)) ] Moving file -> ${n} to Google Drive."
-			rclone move $rclone_options "$@" "$n" "$(printenv RCLONE_CLOUD_ENDPOINT)${destpath}" >/dev/null 2>&1
+			rclone move $rclone_options --delete-after "$@" "$n" "$(printenv RCLONE_CLOUD_ENDPOINT)${destpath}" >/dev/null 2>&1
 		done
 
 	find "${local_decrypt_dir}" -mindepth 1 -type d -empty -delete
@@ -69,7 +69,7 @@ rm_instant () {
 
 			# Move file to remote destination[s], retaining path
 			echo "[ $(date $(printenv DATE_FORMAT)) ] Moving file -> ${n} to Google Drive."
-			rclone move $rclone_options "$@" "$n" "$(printenv RCLONE_CLOUD_ENDPOINT)${destpath}" >/dev/null 2>&1
+			rclone move $rclone_options --delete-after "$@" "$n" "$(printenv RCLONE_CLOUD_ENDPOINT)${destpath}" >/dev/null 2>&1
 		done
 
 	find "${local_decrypt_dir}" -mindepth 1 -type d -empty -delete
@@ -123,7 +123,7 @@ rm_space () {
 
 			# Move file to remote destination[s], retaining path
 			echo "[ $(date $(printenv DATE_FORMAT)) ] Moving file -> ${n} to Google Drive. Freeing up ${fileSizeGb} GB"
-			rclone move $rclone_options "$@" "$n" "$(printenv RCLONE_CLOUD_ENDPOINT)${destpath}" >/dev/null 2>&1
+			rclone move $rclone_options --delete-after "$@" "$n" "$(printenv RCLONE_CLOUD_ENDPOINT)${destpath}" >/dev/null 2>&1
 		done
 
 	find "${local_decrypt_dir}" -mindepth 1 -type d -empty -delete


### PR DESCRIPTION
Added --delete-after to prevent accidental deletions if the transfer is interrupted. Did not add to config since rclone_options is used for copy also and --delete-after should only be used for move.